### PR TITLE
Feat/align with vc api spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A basic endpoint that gives the verification status of a certificate.
 *Request*:
 
 ```javascript
-    const verificationStatus = await fetch('http://localhost:9000/verification', {
+    const verificationStatus = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
             certificate: blockcerts
         }),
@@ -52,7 +52,7 @@ and their status.
 *Request*: 
 
 ```javascript
-  const verificationStatus = await fetch('http://localhost:9000/verification/verbose', {
+  const verificationStatus = await fetch('http://localhost:9000/credentials/verify/verbose', {
         body: JSON.stringify({
             certificate: blockcerts
         }),

--- a/src/helpers/init-cert-verifier-js.ts
+++ b/src/helpers/init-cert-verifier-js.ts
@@ -3,7 +3,9 @@ import {
   VERIFICATION_STATUSES as E_VERIFICATION_STATUSES
 } from '@blockcerts/cert-verifier-js';
 import certVerifierJs from '@blockcerts/cert-verifier-js/dist/verifier-node';
-import invalidCertificateProblemDetailsGenerator, {ProblemDetails} from "./invalid-certificate-problem-details-generator";
+import invalidCertificateProblemDetailsGenerator, { ProblemDetails } from './invalid-certificate-problem-details-generator';
+import type { Request} from 'express';
+import type { APIPayload } from '../models/APIPayload';
 
 const { Certificate, VERIFICATION_STATUSES } = certVerifierJs;
 
@@ -20,13 +22,13 @@ export interface CertificateInitSuccess {
   statusCode: number;
 }
 
-export default async function initCertVerifierJs (req): Promise<CertificateInitSuccess | CertificateInitError | ProblemDetails> {
+export default async function initCertVerifierJs (req:  Request<{}, {}, APIPayload>): Promise<CertificateInitSuccess | CertificateInitError | ProblemDetails> {
   const problemDetails = invalidCertificateProblemDetailsGenerator(req);
   if (problemDetails !== null) {
     return problemDetails;
   }
 
-  const certData = req.body.certificate;
+  const certData = req.body.verifiableCredential;
   try {
     const certificate = new Certificate(certData, req.body.options);
     await certificate.init();

--- a/src/helpers/invalid-certificate-problem-details-generator.ts
+++ b/src/helpers/invalid-certificate-problem-details-generator.ts
@@ -1,20 +1,23 @@
+import type { Request } from 'express';
+import type { APIPayload } from '../models/APIPayload';
+
 export interface ProblemDetails {
   title: string;
   detail: string;
   statusCode: number;
 }
 
-export default function invalidCertificateProblemDetailsGenerator (req): ProblemDetails {
+export default function invalidCertificateProblemDetailsGenerator (req: Request<{}, {}, APIPayload>): ProblemDetails {
   const title = 'Invalid certificate definition';
   let detail = '';
 
-  if (!req.body.certificate) {
+  if (!req.body.verifiableCredential) {
     detail = 'No certificate definition provided.';
-  } else if (typeof req.body.certificate !== 'object') {
+  } else if (typeof req.body.verifiableCredential !== 'object') {
     detail = 'Certificate definition must be an object.';
-  } else if (Array.isArray(req.body.certificate)) {
+  } else if (Array.isArray(req.body.verifiableCredential)) {
     detail = 'Certificate definition must be an object, not an array.';
-  } else if (Object.keys(req.body.certificate).length === 0) {
+  } else if (Object.keys(req.body.verifiableCredential).length === 0) {
     detail = 'Certificate definition must not be an empty object.';
   }
 

--- a/src/middlewares/api-documentation-response.ts
+++ b/src/middlewares/api-documentation-response.ts
@@ -3,12 +3,12 @@ import type { Request, Response } from 'express';
 export default function apiDocumentationResponse (req: Request, res: Response<string>) {
   res.send(`Cert-verifier-js server is running. 
   
-  ** POST to /verification endpoint to verify your blockcerts.
+  ** POST to /credentials/verify endpoint to verify your blockcerts.
     - expected request payload: 
     
     {
       body: JSON.stringify({
-        certificate // blockcerts document, only one document at a time
+        verifiableCredential // blockcerts document, only one document at a time
       }),
       method: 'POST',
       headers: { 'Content-Type': 'application/json' }
@@ -26,12 +26,12 @@ export default function apiDocumentationResponse (req: Request, res: Response<st
       }
     }
   
-  ** POST to /verification/verbose endpoint to verify your blockcerts and get a detailed verification process information.
+  ** POST to /credentials/verify/verbose endpoint to verify your blockcerts and get a detailed verification process information.
     - expected request payload: 
     
     {
       body: JSON.stringify({
-        certificate // blockcerts document, only one document at a time
+        verifiableCredential // blockcerts document, only one document at a time
       }),
       method: 'POST',
       headers: { 'Content-Type': 'application/json' }

--- a/src/middlewares/basic-verification.ts
+++ b/src/middlewares/basic-verification.ts
@@ -1,25 +1,54 @@
 import certVerifierJs from '@blockcerts/cert-verifier-js/dist/verifier-node';
 import type { APIResponse } from '../models/APIResponse';
 import type { Request, Response } from 'express';
-import type { APIPayload } from  '../models/APIPayload';
-import type { Certificate } from '@blockcerts/cert-verifier-js';
+import type { APIPayload } from '../models/APIPayload';
+import type { Certificate, IVerificationStepCallbackAPI } from '@blockcerts/cert-verifier-js';
 
 const { VERIFICATION_STATUSES } = certVerifierJs;
 
-function createResponseBody (req: Request<{}, {}, APIPayload>, status: typeof VERIFICATION_STATUSES, message: string): APIResponse {
+// export interface IVerificationStepCallbackAPI {
+//   code: string;
+//   label: string;
+//   status: VERIFICATION_STATUSES;
+//   errorMessage?: string;
+//   parentStep: string;
+// }
+
+function verificationCbFactory (checks: string[], errors: string[]) {
+  return function verificationCb (verificationEvent: IVerificationStepCallbackAPI) {
+    if (verificationEvent.status === VERIFICATION_STATUSES.SUCCESS) {
+      checks.push(verificationEvent.code);
+    } else if (verificationEvent.status === VERIFICATION_STATUSES.FAILURE) {
+      errors.push(`${verificationEvent.code}: ${verificationEvent.errorMessage}`);
+    }
+  };
+}
+
+function createResponseBody (
+  req: Request<{}, {}, APIPayload>,
+  status: typeof VERIFICATION_STATUSES,
+  message: string,
+  checks: string[],
+  errors: string[]
+): APIResponse {
   const id = req.body.verifiableCredential.id;
   const verifiedCredential = req.body.options?.returnCredential ? req.body.verifiableCredential : undefined;
   return {
     id,
     status,
     message,
-    verifiedCredential
+    verifiedCredential,
+    checks,
+    errors
   };
 }
 
 export default async function basicVerification (req: Request<{}, {}, APIPayload>, res: Response<APIResponse>, certificate: Certificate) {
+  const checks: string[] = [];
+  const errors: string[] = [];
+
   await certificate
-    .verify()
+    .verify(verificationCbFactory(checks, errors))
     .then(({ status, message }) => {
       console.log('Verification status:', status);
 
@@ -27,10 +56,10 @@ export default async function basicVerification (req: Request<{}, {}, APIPayload
         console.error(`The certificate ${req.body.verifiableCredential.id} is not valid. Error: ${message}`);
       }
 
-      return res.json(createResponseBody(req, status, message));
+      return res.json(createResponseBody(req, status, message, checks, errors));
     })
     .catch(err => {
       console.error(err);
-      res.json(createResponseBody(req, VERIFICATION_STATUSES.FAILURE, err));
+      res.json(createResponseBody(req, VERIFICATION_STATUSES.FAILURE, err, checks, errors));
     });
 }

--- a/src/middlewares/basic-verification.ts
+++ b/src/middlewares/basic-verification.ts
@@ -6,28 +6,31 @@ import type { Certificate } from '@blockcerts/cert-verifier-js';
 
 const { VERIFICATION_STATUSES } = certVerifierJs;
 
+function createResponseBody (req: Request<{}, {}, APIPayload>, status: typeof VERIFICATION_STATUSES, message: string): APIResponse {
+  const id = req.body.verifiableCredential.id;
+  const verifiedCredential = req.body.options?.returnCredential ? req.body.verifiableCredential : undefined;
+  return {
+    id,
+    status,
+    message,
+    verifiedCredential
+  };
+}
+
 export default async function basicVerification (req: Request<{}, {}, APIPayload>, res: Response<APIResponse>, certificate: Certificate) {
   await certificate
     .verify()
     .then(({ status, message }) => {
-      console.log('Status:', status);
+      console.log('Verification status:', status);
 
       if (status === VERIFICATION_STATUSES.FAILURE) {
-        console.log(`The certificate ${req.body.verifiableCredential.id} is not valid. Error: ${message}`);
+        console.error(`The certificate ${req.body.verifiableCredential.id} is not valid. Error: ${message}`);
       }
 
-      return res.json({
-        id: req.body.verifiableCredential.id,
-        status,
-        message
-      });
+      return res.json(createResponseBody(req, status, message));
     })
     .catch(err => {
-      console.log(err);
-      res.json({
-        id: req.body.verifiableCredential.id,
-        status: VERIFICATION_STATUSES.FAILURE,
-        message: err
-      });
+      console.error(err);
+      res.json(createResponseBody(req, VERIFICATION_STATUSES.FAILURE, err));
     });
 }

--- a/src/middlewares/basic-verification.ts
+++ b/src/middlewares/basic-verification.ts
@@ -13,11 +13,11 @@ export default async function basicVerification (req: Request<{}, {}, APIPayload
       console.log('Status:', status);
 
       if (status === VERIFICATION_STATUSES.FAILURE) {
-        console.log(`The certificate ${req.body.certificate.id} is not valid. Error: ${message}`);
+        console.log(`The certificate ${req.body.verifiableCredential.id} is not valid. Error: ${message}`);
       }
 
       return res.json({
-        id: req.body.certificate.id,
+        id: req.body.verifiableCredential.id,
         status,
         message
       });
@@ -25,7 +25,7 @@ export default async function basicVerification (req: Request<{}, {}, APIPayload
     .catch(err => {
       console.log(err);
       res.json({
-        id: req.body.certificate.id,
+        id: req.body.verifiableCredential.id,
         status: VERIFICATION_STATUSES.FAILURE,
         message: err
       });

--- a/src/middlewares/handle-certificate-error.ts
+++ b/src/middlewares/handle-certificate-error.ts
@@ -1,9 +1,11 @@
 import type { CertificateInitError } from '../helpers/init-cert-verifier-js';
+import type { Request } from 'express';
+import type { APIPayload } from '../models/APIPayload';
 
-export default function handleCertificateError (req, res, initializationResult) {
+export default function handleCertificateError (req: Request<{}, {}, APIPayload>, res, initializationResult) {
   console.error('An error occured initializing the certificate verifier', initializationResult);
   res.json({
-    id: req.body.certificate.id,
+    id: req.body.verifiableCredential.id,
     status: (initializationResult as CertificateInitError).status,
     message: (initializationResult as CertificateInitError).message
   });

--- a/src/middlewares/handle-certificate-problem-details.ts
+++ b/src/middlewares/handle-certificate-problem-details.ts
@@ -1,4 +1,4 @@
-import { ProblemDetails } from '../helpers/invalid-certificate-problem-details-generator';
+import type { ProblemDetails } from '../helpers/invalid-certificate-problem-details-generator';
 
 export default function handleCertificateProblemDetails (req, res, problemDetails: ProblemDetails) {
   console.error('An error occured receiving the certificate definition', problemDetails);

--- a/src/middlewares/verbose-verification.ts
+++ b/src/middlewares/verbose-verification.ts
@@ -155,7 +155,7 @@ export default async function verboseVerification (req: Request<{}, {}, APIPaylo
   const verification = await certificate.verify(verificationCb);
 
   res.json({
-    id: req.body.certificate.id,
+    id: req.body.verifiableCredential.id,
     status: verification.status,
     message: verification.message,
     verificationSteps,

--- a/src/middlewares/verbose-verification.ts
+++ b/src/middlewares/verbose-verification.ts
@@ -163,7 +163,9 @@ function createResponseBody (
     verificationSteps,
     issuanceDate: getIssuanceDate(certificate),
     signers: getSigners(certificate),
-    metadata: getMetadata(certificate)
+    metadata: getMetadata(certificate),
+    checks: [],
+    errors: []
   };
 }
 

--- a/src/middlewares/verbose-verification.ts
+++ b/src/middlewares/verbose-verification.ts
@@ -146,21 +146,44 @@ function stepVerified (verificationSteps: IVerificationMapItem[], step: Verifica
   return verificationSteps;
 }
 
+function createResponseBody (
+  req: Request<{}, {}, APIPayload>,
+  status: typeof VERIFICATION_STATUSES,
+  message: string,
+  verificationSteps: IVerificationMapItem[],
+  certificate: Certificate
+): VerboseVerificationAPIResponse {
+  const id = req.body.verifiableCredential.id;
+  const verifiedCredential = req.body.options?.returnCredential ? req.body.verifiableCredential : undefined;
+  return {
+    id,
+    status,
+    message,
+    verifiedCredential,
+    verificationSteps,
+    issuanceDate: getIssuanceDate(certificate),
+    signers: getSigners(certificate),
+    metadata: getMetadata(certificate)
+  };
+}
+
 export default async function verboseVerification (req: Request<{}, {}, APIPayload>, res: Response<VerboseVerificationAPIResponse>, certificate: Certificate): Promise<void> {
   let verificationSteps = initializeVerificationSteps(certificate);
   function verificationCb (verifiedStep) {
     stepVerified(verificationSteps, verifiedStep);
   }
 
-  const verification = await certificate.verify(verificationCb);
+  await certificate
+    .verify(verificationCb)
+    .then(({ status, message }) => {
+      console.log('Verification status:', status);
 
-  res.json({
-    id: req.body.verifiableCredential.id,
-    status: verification.status,
-    message: verification.message,
-    verificationSteps,
-    issuanceDate: getIssuanceDate(certificate),
-    signers: getSigners(certificate),
-    metadata: getMetadata(certificate)
-  });
+      if (status === VERIFICATION_STATUSES.FAILURE) {
+        console.error(`The certificate ${req.body.verifiableCredential.id} is not valid. Error: ${message}`);
+      }
+      res.json(createResponseBody(req, status, message, verificationSteps, certificate));
+    }).catch(err => {
+      console.error(err);
+      res.json(createResponseBody(req, VERIFICATION_STATUSES.FAILURE, err, verificationSteps, certificate));
+    });
 }

--- a/src/models/APIPayload.ts
+++ b/src/models/APIPayload.ts
@@ -1,6 +1,6 @@
 import type { Blockcerts, CertificateOptions } from '@blockcerts/cert-verifier-js';
 
 export interface APIPayload {
-  certificate: Blockcerts;
+  verifiableCredential: Blockcerts;
   options?: CertificateOptions;
 }

--- a/src/models/APIPayload.ts
+++ b/src/models/APIPayload.ts
@@ -1,6 +1,10 @@
 import type { Blockcerts, CertificateOptions } from '@blockcerts/cert-verifier-js';
 
+interface APIPayloadOptions extends CertificateOptions {
+  returnCredential?: boolean;
+}
+
 export interface APIPayload {
   verifiableCredential: Blockcerts;
-  options?: CertificateOptions;
+  options?: APIPayloadOptions;
 }

--- a/src/models/APIResponse.ts
+++ b/src/models/APIResponse.ts
@@ -4,6 +4,7 @@ export interface APIResponse {
   id?: string;
   status?: VERIFICATION_STATUSES;
   message?: string;
+  verifiedCredential?: any;
 
   // RFC9457
   title?: string;

--- a/src/models/APIResponse.ts
+++ b/src/models/APIResponse.ts
@@ -4,7 +4,12 @@ export interface APIResponse {
   id?: string;
   status?: VERIFICATION_STATUSES;
   message?: string;
-  verifiedCredential?: any;
+
+  // VC-API
+  verifiedCredential?: any; // at risk, might become `credential`: https://github.com/w3c-ccg/vc-api/issues/381
+  checks: string[];
+  errors: string[];
+  warnings?: string[];
 
   // RFC9457
   title?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ server.get('/', (req, res) => {
   apiDocumentationResponse(req, res);
 });
 
-server.post('/verification', async (req: Request<{}, {}, APIPayload>, res: Response<APIResponse>): Promise<void> => {
+server.post('/credentials/verify', async (req: Request<{}, {}, APIPayload>, res: Response<APIResponse>): Promise<void> => {
   console.log('calling basic verification endpoint');
   const initializationResult = await initCertVerifierJs(req);
   if ((initializationResult as ProblemDetails).statusCode !== 200) {
@@ -34,7 +34,7 @@ server.post('/verification', async (req: Request<{}, {}, APIPayload>, res: Respo
 
   await basicVerification(req, res, (initializationResult as CertificateInitSuccess).certificate);
 });
-server.post('/verification/verbose', async (req: Request<{}, {}, APIPayload>, res: Response<VerboseVerificationAPIResponse | APIResponse>): Promise<void> => {
+server.post('/credentials/verify/verbose', async (req: Request<{}, {}, APIPayload>, res: Response<VerboseVerificationAPIResponse | APIResponse>): Promise<void> => {
   console.log('calling verbose verification endpoint');
   const initializationResult = await initCertVerifierJs(req);
   if ((initializationResult as ProblemDetails).statusCode !== 200) {

--- a/test/contract/basic-verification.test.docker.ts
+++ b/test/contract/basic-verification.test.docker.ts
@@ -16,6 +16,19 @@ describe('basic verification docker endpoint test suite', function () {
       }).then((res) => res.json());
 
       expect(output).toEqual({
+        checks: [
+          "getTransactionId",
+          "computeLocalHash",
+          "fetchRemoteHash",
+          "compareHashes",
+          "checkMerkleRoot",
+          "checkReceipt",
+          "parseIssuerKeys",
+          "checkAuthenticity",
+          "checkRevokedStatus",
+          "checkExpiresDate",
+        ],
+        errors: [],
         id: 'urn:uuid:bbba8553-8ec1-445f-82c9-a57251dd731c',
         status: 'success',
         message: {
@@ -39,6 +52,12 @@ describe('basic verification docker endpoint test suite', function () {
       }).then((res) => res.json());
 
       expect(output).toEqual({
+        checks: [
+          "getTransactionId",
+          "computeLocalHash",
+          "fetchRemoteHash"
+        ],
+        errors: ['compareHashes: Computed hash does not match remote hash'],
         id: 'urn:uuid:bbba8553-8ec1-445f-82c9-a57251dd731c',
         status: 'failure',
         message: 'Computed hash does not match remote hash'

--- a/test/contract/basic-verification.test.docker.ts
+++ b/test/contract/basic-verification.test.docker.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch-commonjs';
 import singleSignatureCert from '../fixtures/single-signature-cert.json';
 import failingSignatureCert from '../fixtures/failing-signature-cert.json';
+import type { APIPayload } from '../../src/models/APIPayload';
 
 describe('basic verification docker endpoint test suite', function () {
   describe('when the certificate is valid', function () {
@@ -8,8 +9,8 @@ describe('basic verification docker endpoint test suite', function () {
       const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
       const output = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
-          certificate: fixture
-        }),
+          verifiableCredential: fixture
+        } as APIPayload),
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
       }).then((res) => res.json());
@@ -31,8 +32,8 @@ describe('basic verification docker endpoint test suite', function () {
       const fixture = JSON.parse(JSON.stringify(failingSignatureCert));
       const output = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
-          certificate: fixture
-        }),
+          verifiableCredential: fixture
+        } as APIPayload),
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
       }).then((res) => res.json());

--- a/test/contract/basic-verification.test.docker.ts
+++ b/test/contract/basic-verification.test.docker.ts
@@ -6,7 +6,7 @@ describe('basic verification docker endpoint test suite', function () {
   describe('when the certificate is valid', function () {
     it('should return the expected payload', async function () {
       const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
-      const output = await fetch('http://localhost:9000/verification', {
+      const output = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
           certificate: fixture
         }),
@@ -29,7 +29,7 @@ describe('basic verification docker endpoint test suite', function () {
   describe('when the certificate is invalid', function () {
     it('should return the expected payload', async function () {
       const fixture = JSON.parse(JSON.stringify(failingSignatureCert));
-      const output = await fetch('http://localhost:9000/verification', {
+      const output = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
           certificate: fixture
         }),

--- a/test/contract/failures.test.docker.ts
+++ b/test/contract/failures.test.docker.ts
@@ -11,7 +11,7 @@ describe('failure handling docker endpoint test suite', function () {
       fixture.issuer = 'https://this.url.leads.to.nowhere';
       output = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
-          certificate: fixture
+          verifiableCredential: fixture
         }),
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
@@ -39,7 +39,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: ''
+              verifiableCredential: ''
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -71,7 +71,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: 'certificate'
+              verifiableCredential: 'certificate'
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -103,7 +103,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: true
+              verifiableCredential: true
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -135,7 +135,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: 42
+              verifiableCredential: 42
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -167,7 +167,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: ['certificate']
+              verifiableCredential: ['certificate']
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -199,7 +199,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: []
+              verifiableCredential: []
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -231,7 +231,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: undefined
+              verifiableCredential: undefined
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -293,7 +293,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: null
+              verifiableCredential: null
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -325,7 +325,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
-              certificate: {}
+              verifiableCredential: {}
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -361,7 +361,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: ''
+              verifiableCredential: ''
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -393,7 +393,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: 'certificate'
+              verifiableCredential: 'certificate'
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -425,7 +425,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: true
+              verifiableCredential: true
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -457,7 +457,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: 42
+              verifiableCredential: 42
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -489,7 +489,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: ['certificate']
+              verifiableCredential: ['certificate']
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -521,7 +521,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: []
+              verifiableCredential: []
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -613,7 +613,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: null
+              verifiableCredential: null
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -645,7 +645,7 @@ describe('failure handling docker endpoint test suite', function () {
         beforeAll(async function () {
           output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
-              certificate: {}
+              verifiableCredential: {}
             }),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }

--- a/test/contract/failures.test.docker.ts
+++ b/test/contract/failures.test.docker.ts
@@ -9,7 +9,7 @@ describe('failure handling docker endpoint test suite', function () {
     beforeAll(async function () {
       const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
       fixture.issuer = 'https://this.url.leads.to.nowhere';
-      output = await fetch('http://localhost:9000/verification', {
+      output = await fetch('http://localhost:9000/credentials/verify', {
         body: JSON.stringify({
           certificate: fixture
         }),
@@ -37,7 +37,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: ''
             }),
@@ -69,7 +69,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: 'certificate'
             }),
@@ -101,7 +101,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: true
             }),
@@ -133,7 +133,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: 42
             }),
@@ -165,7 +165,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: ['certificate']
             }),
@@ -197,7 +197,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: []
             }),
@@ -229,7 +229,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: undefined
             }),
@@ -261,7 +261,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify([]),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -291,7 +291,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: null
             }),
@@ -323,7 +323,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification', {
+          output = await fetch('http://localhost:9000/credentials/verify', {
             body: JSON.stringify({
               certificate: {}
             }),
@@ -359,7 +359,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: ''
             }),
@@ -391,7 +391,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: 'certificate'
             }),
@@ -423,7 +423,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: true
             }),
@@ -455,7 +455,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: 42
             }),
@@ -487,7 +487,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: ['certificate']
             }),
@@ -519,7 +519,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: []
             }),
@@ -551,7 +551,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({}),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -581,7 +581,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify([]),
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
@@ -611,7 +611,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: null
             }),
@@ -643,7 +643,7 @@ describe('failure handling docker endpoint test suite', function () {
         let output;
 
         beforeAll(async function () {
-          output = await fetch('http://localhost:9000/verification/verbose', {
+          output = await fetch('http://localhost:9000/credentials/verify/verbose', {
             body: JSON.stringify({
               certificate: {}
             }),

--- a/test/contract/returnCredential.test.docker.ts
+++ b/test/contract/returnCredential.test.docker.ts
@@ -1,0 +1,52 @@
+import fetch from 'node-fetch-commonjs';
+import type { APIPayload } from '../../src/models/APIPayload';
+import singleSignatureCert from '../fixtures/single-signature-cert.json';
+import type { APIResponse } from "../../src/models/APIResponse";
+
+describe('when the returnCredential property is set to true', function () {
+  it('should return the verified credential', async function () {
+    const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+    const output = await fetch('http://localhost:9000/credentials/verify', {
+      body: JSON.stringify({
+        verifiableCredential: fixture,
+        options: { returnCredential: true }
+      } as APIPayload),
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }).then((res) => res.json());
+
+    expect((output as APIResponse).verifiedCredential).toEqual(fixture);
+  });
+});
+
+describe('when the returnCredential property is set to false', function () {
+  it('should not return the verified credential', async function () {
+    const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+    const output = await fetch('http://localhost:9000/credentials/verify', {
+      body: JSON.stringify({
+        verifiableCredential: fixture,
+        options: { returnCredential: false }
+      } as APIPayload),
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }).then((res) => res.json());
+
+    expect((output as APIResponse).verifiedCredential).toBeUndefined();
+  });
+});
+
+describe('when the returnCredential property is not set', function () {
+  it('should not return the verified credential', async function () {
+    const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+    const output = await fetch('http://localhost:9000/credentials/verify', {
+      body: JSON.stringify({
+        verifiableCredential: fixture,
+        options: {}
+      } as APIPayload),
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    }).then((res) => res.json());
+
+    expect((output as APIResponse).verifiedCredential).toBeUndefined();
+  });
+});

--- a/test/contract/returnCredential.test.docker.ts
+++ b/test/contract/returnCredential.test.docker.ts
@@ -1,8 +1,8 @@
 import fetch from 'node-fetch-commonjs';
 import type { APIPayload } from '../../src/models/APIPayload';
 import singleSignatureCert from '../fixtures/single-signature-cert.json';
-import type { APIResponse } from "../../src/models/APIResponse";
-import {VerboseVerificationAPIResponse} from "../../src/middlewares/verbose-verification";
+import type { APIResponse } from '../../src/models/APIResponse';
+import type { VerboseVerificationAPIResponse } from '../../src/middlewares/verbose-verification';
 
 describe('basic verification endpoint', function () {
   const BASIC_ENDPOINT_URL = 'http://localhost:9000/credentials/verify';

--- a/test/contract/returnCredential.test.docker.ts
+++ b/test/contract/returnCredential.test.docker.ts
@@ -2,51 +2,109 @@ import fetch from 'node-fetch-commonjs';
 import type { APIPayload } from '../../src/models/APIPayload';
 import singleSignatureCert from '../fixtures/single-signature-cert.json';
 import type { APIResponse } from "../../src/models/APIResponse";
+import {VerboseVerificationAPIResponse} from "../../src/middlewares/verbose-verification";
 
-describe('when the returnCredential property is set to true', function () {
-  it('should return the verified credential', async function () {
-    const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
-    const output = await fetch('http://localhost:9000/credentials/verify', {
-      body: JSON.stringify({
-        verifiableCredential: fixture,
-        options: { returnCredential: true }
-      } as APIPayload),
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' }
-    }).then((res) => res.json());
+describe('basic verification endpoint', function () {
+  const BASIC_ENDPOINT_URL = 'http://localhost:9000/credentials/verify';
 
-    expect((output as APIResponse).verifiedCredential).toEqual(fixture);
+  describe('when the returnCredential property is set to true', function () {
+    it('should return the verified credential', async function () {
+      const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+      const output = await fetch(BASIC_ENDPOINT_URL, {
+        body: JSON.stringify({
+          verifiableCredential: fixture,
+          options: {returnCredential: true}
+        } as APIPayload),
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then((res) => res.json());
+
+      expect((output as APIResponse).verifiedCredential).toEqual(fixture);
+    });
+  });
+
+  describe('when the returnCredential property is set to false', function () {
+    it('should not return the verified credential', async function () {
+      const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+      const output = await fetch(BASIC_ENDPOINT_URL, {
+        body: JSON.stringify({
+          verifiableCredential: fixture,
+          options: {returnCredential: false}
+        } as APIPayload),
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then((res) => res.json());
+
+      expect((output as APIResponse).verifiedCredential).toBeUndefined();
+    });
+  });
+
+  describe('when the returnCredential property is not set', function () {
+    it('should not return the verified credential', async function () {
+      const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+      const output = await fetch(BASIC_ENDPOINT_URL, {
+        body: JSON.stringify({
+          verifiableCredential: fixture,
+          options: {}
+        } as APIPayload),
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then((res) => res.json());
+
+      expect((output as APIResponse).verifiedCredential).toBeUndefined();
+    });
   });
 });
 
-describe('when the returnCredential property is set to false', function () {
-  it('should not return the verified credential', async function () {
-    const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
-    const output = await fetch('http://localhost:9000/credentials/verify', {
-      body: JSON.stringify({
-        verifiableCredential: fixture,
-        options: { returnCredential: false }
-      } as APIPayload),
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' }
-    }).then((res) => res.json());
 
-    expect((output as APIResponse).verifiedCredential).toBeUndefined();
+describe('verbose verification endpoint', function () {
+  const VERBOSE_ENDPOINT_URL = 'http://localhost:9000/credentials/verify/verbose';
+
+  describe('when the returnCredential property is set to true', function () {
+    it('should return the verified credential', async function () {
+      const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+      const output = await fetch(VERBOSE_ENDPOINT_URL, {
+        body: JSON.stringify({
+          verifiableCredential: fixture,
+          options: {returnCredential: true}
+        } as APIPayload),
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then((res) => res.json());
+
+      expect((output as VerboseVerificationAPIResponse).verifiedCredential).toEqual(fixture);
+    });
   });
-});
 
-describe('when the returnCredential property is not set', function () {
-  it('should not return the verified credential', async function () {
-    const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
-    const output = await fetch('http://localhost:9000/credentials/verify', {
-      body: JSON.stringify({
-        verifiableCredential: fixture,
-        options: {}
-      } as APIPayload),
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' }
-    }).then((res) => res.json());
+  describe('when the returnCredential property is set to false', function () {
+    it('should not return the verified credential', async function () {
+      const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+      const output = await fetch(VERBOSE_ENDPOINT_URL, {
+        body: JSON.stringify({
+          verifiableCredential: fixture,
+          options: {returnCredential: false}
+        } as APIPayload),
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then((res) => res.json());
 
-    expect((output as APIResponse).verifiedCredential).toBeUndefined();
+      expect((output as VerboseVerificationAPIResponse).verifiedCredential).toBeUndefined();
+    });
+  });
+
+  describe('when the returnCredential property is not set', function () {
+    it('should not return the verified credential', async function () {
+      const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
+      const output = await fetch(VERBOSE_ENDPOINT_URL, {
+        body: JSON.stringify({
+          verifiableCredential: fixture,
+          options: {}
+        } as APIPayload),
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then((res) => res.json());
+
+      expect((output as VerboseVerificationAPIResponse).verifiedCredential).toBeUndefined();
+    });
   });
 });

--- a/test/contract/verbose-verification.test.docker.ts
+++ b/test/contract/verbose-verification.test.docker.ts
@@ -3,6 +3,7 @@ import singleSignatureCert from '../fixtures/single-signature-cert.json';
 import singleSignatureCertVerifiedStepAssertion from '../assertions/single-signature-cert-verified-steps.json';
 import failingSignatureCert from '../fixtures/failing-signature-cert.json';
 import failingSignatureCertVerifiedStepAssertion from '../assertions/failing-signature-cert-verified-steps.json';
+import type { APIPayload } from '../../src/models/APIPayload';
 
 describe('verbose verification docker endpoint test suite', function () {
   let output;
@@ -12,8 +13,8 @@ describe('verbose verification docker endpoint test suite', function () {
       const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
       output = await fetch('http://localhost:9000/credentials/verify/verbose', {
         body: JSON.stringify({
-          certificate: fixture
-        }),
+          verifiableCredential: fixture
+        } as APIPayload),
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
       }).then((res) => res.json());
@@ -83,8 +84,8 @@ describe('verbose verification docker endpoint test suite', function () {
       const fixture = JSON.parse(JSON.stringify(failingSignatureCert));
       output = await fetch('http://localhost:9000/credentials/verify/verbose', {
         body: JSON.stringify({
-          certificate: fixture
-        }),
+          verifiableCredential: fixture
+        } as APIPayload),
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
       }).then((res) => res.json());

--- a/test/contract/verbose-verification.test.docker.ts
+++ b/test/contract/verbose-verification.test.docker.ts
@@ -10,7 +10,7 @@ describe('verbose verification docker endpoint test suite', function () {
   describe('given the certificate is valid', function () {
     beforeAll(async function () {
       const fixture = JSON.parse(JSON.stringify(singleSignatureCert));
-      output = await fetch('http://localhost:9000/verification/verbose', {
+      output = await fetch('http://localhost:9000/credentials/verify/verbose', {
         body: JSON.stringify({
           certificate: fixture
         }),
@@ -81,7 +81,7 @@ describe('verbose verification docker endpoint test suite', function () {
   describe('given the certificate is invalid', function () {
     beforeAll(async function () {
       const fixture = JSON.parse(JSON.stringify(failingSignatureCert));
-      output = await fetch('http://localhost:9000/verification/verbose', {
+      output = await fetch('http://localhost:9000/credentials/verify/verbose', {
         body: JSON.stringify({
           certificate: fixture
         }),

--- a/test/contract/verbose-verification.test.docker.ts
+++ b/test/contract/verbose-verification.test.docker.ts
@@ -77,6 +77,25 @@ describe('verbose verification docker endpoint test suite', function () {
     it('should expose the document\'s metadata', function () {
       expect(output.metadata).toEqual(null);
     });
+
+    it('should expose the checks array to conform with VC-API', function () {
+      expect(output.checks).toEqual([
+        "getTransactionId",
+        "computeLocalHash",
+        "fetchRemoteHash",
+        "compareHashes",
+        "checkMerkleRoot",
+        "checkReceipt",
+        "parseIssuerKeys",
+        "checkAuthenticity",
+        "checkRevokedStatus",
+        "checkExpiresDate",
+      ]);
+    });
+
+    it('should expose an empty errors array to conform with VC-API', function () {
+      expect(output.errors).toEqual([]);
+    });
   });
 
   describe('given the certificate is invalid', function () {
@@ -143,6 +162,18 @@ describe('verbose verification docker endpoint test suite', function () {
 
     it('should expose the document\'s metadata', function () {
       expect(output.metadata).toEqual(null);
+    });
+
+    it('should expose the checks array to conform with VC-API', function () {
+      expect(output.checks).toEqual([
+        "getTransactionId",
+        "computeLocalHash",
+        "fetchRemoteHash"
+      ]);
+    });
+
+    it('should expose the errors array to conform with VC-API', function () {
+      expect(output.errors).toEqual(['compareHashes: Computed hash does not match remote hash']);
     });
   });
 });

--- a/test/helpers/init-cert-verifier-js.test.ts
+++ b/test/helpers/init-cert-verifier-js.test.ts
@@ -10,13 +10,13 @@ describe('initCertVerifierJs test suite', function () {
       it('should pass the information to the CVJS library', async function () {
         const req: Partial<Request<unknown, unknown, APIPayload>> = {
           body: {
-            certificate: fixture,
+            verifiableCredential: fixture,
             options: {
               locale: 'fr-FR'
             }
           }
         };
-        const result = await initCertVerifierJs(req);
+        const result = await initCertVerifierJs(req as any);
         expect((result as CertificateInitSuccess).certificate.locale).toBe('fr');
       });
     });
@@ -25,10 +25,10 @@ describe('initCertVerifierJs test suite', function () {
       it('should use the default language', async function () {
         const req: Partial<Request<unknown, unknown, APIPayload>> = {
           body: {
-            certificate: fixture
+            verifiableCredential: fixture
           }
         };
-        const result = await initCertVerifierJs(req);
+        const result = await initCertVerifierJs(req as any);
         expect((result as CertificateInitSuccess).certificate.locale).toBe('en-US');
       });
     });

--- a/test/middlewares/verbose-verification.test.ts
+++ b/test/middlewares/verbose-verification.test.ts
@@ -6,6 +6,9 @@ import singleSignatureCertVerifiedStepAssertion from '../assertions/single-signa
 import multipleSignatureCertVerifiedStepAssertion from '../assertions/multiple-signature-cert-verified-steps.json';
 import failingSignatureCertVerifiedStepAssertion from '../assertions/failing-signature-cert-verified-steps.json';
 import certVerifierJs from '@blockcerts/cert-verifier-js/dist/verifier-node';
+import type { APIPayload } from "../../src/models/APIPayload";
+import type { Request } from 'express';
+
 const { Certificate } = certVerifierJs;
 
 describe('Verbose verification middleware test suite', function () {
@@ -13,9 +16,9 @@ describe('Verbose verification middleware test suite', function () {
     let result;
 
     beforeAll(async function () {
-      const req = {
+      const req: Partial<Request<{}, {}, APIPayload>> = {
         body: {
-          certificate: singleSignatureCert
+          verifiableCredential: singleSignatureCert
         }
       };
 
@@ -85,9 +88,9 @@ describe('Verbose verification middleware test suite', function () {
     it('should provide a verbose feedback of the verification process', async function () {
       let result;
 
-      const req = {
+      const req: Partial<Request<{}, {}, APIPayload>> = {
         body: {
-          certificate: singleSignatureCert
+          verifiableCredential: singleSignatureCert
         }
       };
 
@@ -108,9 +111,9 @@ describe('Verbose verification middleware test suite', function () {
     it('should provide a verbose feedback of the verification process', async function () {
       let result;
 
-      const req = {
+      const req: Partial<Request<{}, {}, APIPayload>> = {
         body: {
-          certificate: multipleSignatureCert
+          verifiableCredential: multipleSignatureCert
         }
       };
 
@@ -130,9 +133,9 @@ describe('Verbose verification middleware test suite', function () {
     it('should provide a verbose feedback of the verification process', async function () {
       let result;
 
-      const req = {
+      const req: Partial<Request<{}, {}, APIPayload>> = {
         body: {
-          certificate: failingSignatureCert
+          verifiableCredential: failingSignatureCert
         }
       };
 


### PR DESCRIPTION
BREAKING CHANGES are:
- endpoints have been renamed: `/verification` to `/credentials/verify`. `/verbose` endpoint is maintained under the new path structure
- in the payload, `certificate` becomes `verifiableCredential`

Other changes include:
- `returnCredential` option in the payload to specify if the verifiable credential is being returned
- response object remains the same as before, with the addition of the `checks` and `errors` array to conform with the VC-API check, but provide more Blockcerts specific information (and more directly consumable information). `warnings` was not implemented as not relevant, yet.